### PR TITLE
Fix device in `regressor.py`

### DIFF
--- a/fast_l1/regressor.py
+++ b/fast_l1/regressor.py
@@ -218,7 +218,7 @@ def train_saga(weight, bias, loader, val_loader, *,
             prev_w[:] = weight
             # Try rearranging weight vector here
             for bool_X, y, idx in iterator:
-                a_prev[:, :num_keep].copy_(a_table[idx, :num_keep],
+                a_prev[:, :num_keep].copy_(a_table[idx.cpu(), :num_keep],
                                            non_blocking=True)
 
                 X.copy_(bool_X)
@@ -338,7 +338,7 @@ def train_saga(weight, bias, loader, val_loader, *,
                 new_done = len(new_fin_inds)
                 inds_to_swap = ch.arange(num_keep - new_done, num_keep)
 
-                inds_to_swap = inds_to_swap[still_opt_outer[inds_to_swap]]
+                inds_to_swap = inds_to_swap[still_opt_outer[inds_to_swap].cpu()]
                 new_fin_inds = new_fin_inds[new_fin_inds < num_keep - new_done]
 
                 for tens in [a_table, w_grad_avg, weight]:


### PR DESCRIPTION
This pull request intends to fix the device of some tensors in `regressor.py` as presented in issue https://github.com/MadryLab/fast_l1/issues/4.

It ensures that both  `idx` and `still_opt_outer` are on the CPU before indexing/slicing.